### PR TITLE
fix: normalize error handling and enable source map support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,6 @@ import { AstPrinter } from "./lox/ast_printer";
 import { Interpreter } from "./lox/interpreter";
 
 function run(source: string): boolean {
-  console.log("running!");
   const scanner = new Scanner(source);
   const tokens = scanner.scanTokens();
 
@@ -25,15 +24,14 @@ function run(source: string): boolean {
   //   return scanner.error;
   const parser = new Parser(tokens);
   const expr = parser.parse();
-  if (expr == null) {
-    return parser.hasError;
+  if (expr == null || parser.error) {
+    return parser.error;
   }
-  //   console.log(new AstPrinter().print(expr));
 
   const interpreter = new Interpreter();
   interpreter.interpret(expr);
 
-  return parser.hasError;
+  return interpreter.error;
 }
 
 async function runFile(filename: string) {

--- a/lox/parser.ts
+++ b/lox/parser.ts
@@ -8,7 +8,7 @@ class ParseError extends Error {}
 export default class Parser {
   private tokens: Token[];
   private current: number = 0;
-  private _hasError = false;
+  private hasError = false;
 
   constructor(tokens: Token[]) {
     this.tokens = tokens;
@@ -16,7 +16,6 @@ export default class Parser {
 
   parse(): Expr | null {
     console.log("Parsing");
-
     try {
       return this.expression();
     } catch (ex) {
@@ -25,12 +24,12 @@ export default class Parser {
     }
   }
 
-  get hasError(): boolean {
-    return this._hasError;
+  get error(): boolean {
+    return this.hasError;
   }
 
-  set hasError(error: boolean) {
-    this._hasError = error;
+  set error(error: boolean) {
+    this.hasError = error;
   }
 
   private expression(): Expr {
@@ -110,7 +109,7 @@ export default class Parser {
       return new Grouping(expr);
     }
 
-    throw this.error(this.peek(), "Expect expression");
+    throw this.reportError(this.peek(), "Expect expression");
   }
 
   private synchronize() {
@@ -171,11 +170,11 @@ export default class Parser {
   private consume(type: string, message: string): Token {
     if (this.check(type)) return this.advance();
 
-    throw this.error(this.peek(), message);
+    throw this.reportError(this.peek(), message);
   }
 
-  private error(token: Token, message: string): ParseError {
-    this.hasError = true;
+  private reportError(token: Token, message: string): ParseError {
+    this.error = true;
 
     if (token.type == TokenType.EOF) {
       report(token.line, ` at end`, message);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "rimraf ./build && tsc",
     "build-ast": "tsc && node build/tools/generate_ast.js lox",
     "prettier-format": "prettier --config .prettierrc '**/*.ts' --write",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts",
+    "interpreter": "npm run build && node --enable-source-maps build/index.js"
   },
   "devDependencies": {
     "@types/node": "^20.14.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,7 +53,7 @@
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./build",                                   /* Specify an output folder for all emitted files. */
     "removeComments": false,                           /* Disable emitting comments. */


### PR DESCRIPTION
Some general improvements to make all classes report errors in the same way. And add support for source maps, so stack traces go back to the TS files.