### PR TITLE
fix: handle error in parsing, so all syntax problems are reported

### DIFF
--- a/lox/parser.ts
+++ b/lox/parser.ts
@@ -18,7 +18,12 @@ export default class Parser {
   parse(): Stmt[] {
     const statements: Stmt[] = [];
     while (!this.isAtEnd()) {
-      statements.push(this.statement());
+      try {
+        statements.push(this.statement());
+      } catch (ex) {
+        // already logged, so allow to fall through
+        // so that _all_ syntax errors get reported in a pass
+      }
     }
 
     return statements;


### PR DESCRIPTION
Currently the exception is allowed to reach the top level. So when  parsing a file you only get the first error reported, and in the REPL you get pushed out altogether.