### PR TITLE
feat: add basic support for variable declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ A Typescript implementation of the _Lox_ programming language interpreter.
 ## Grammar
 | name | rule |
 |------|------|
-| program | statement* EOF |
-| statement | exprStmt | printStmt |
+| program | declaration* EOF |
+| declaration | varDecl \| statement |
+| varDecl | "var" IDENTIFIER ( "=" expression )? ";" |
+| statement | exprStmt \| printStmt |
 | exprStmt | expression ";" |
 | printStmt | "print" expression ";" |
 | expression | equality |
@@ -16,7 +18,7 @@ A Typescript implementation of the _Lox_ programming language interpreter.
 | term | factor ( ( "-" \| "+" ) factor)* |
 | factor | unary ( ( "/" \| "\*" ) unary)* |
 | unary | ( "!" \| "-" ) unary | primary |
-| primary | NUMBER \| STRING \| "true" \| "false" \| "nil" \| "(" expression ")" |
+| primary | NUMBER \| STRING \| "true" \| "false" \| "nil" \| "(" expression ")" \| IDENTIFIER |
 
 
 ### AST generation

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import Scanner from "./lox/scanner";
 import Parser from "./lox/parser";
 import { Interpreter } from "./lox/interpreter";
 
-function run(source: string): boolean {
+function run(source: string, interpreter: Interpreter | null = null): boolean {
   const scanner = new Scanner(source);
   const tokens = scanner.scanTokens();
 
@@ -27,7 +27,7 @@ function run(source: string): boolean {
     return parser.error;
   }
 
-  const interpreter = new Interpreter();
+  interpreter = interpreter || new Interpreter();
   interpreter.interpret(statements);
 
   return interpreter.error;
@@ -50,12 +50,13 @@ async function runPrompt() {
     output: process.stdout,
   });
 
+  const interpreter = new Interpreter();
   for (;;) {
     const line = await rl.question(">>> ");
     if (!line) {
       continue;
     }
-    run(line);
+    run(line, interpreter);
   }
   rl.close();
 }

--- a/lox/ast_printer.ts
+++ b/lox/ast_printer.ts
@@ -1,4 +1,4 @@
-import { Binary, Expr, Grouping, Literal, Unary, Visitor } from "./expr";
+import { Binary, Expr, Grouping, Literal, Unary, Variable, Visitor } from "./expr";
 
 export class AstPrinter implements Visitor<string> {
   print(expr: Expr): string {
@@ -19,6 +19,10 @@ export class AstPrinter implements Visitor<string> {
 
   visitUnaryExpr(expr: Unary): string {
     return this.parenthesize(expr.operator.lexeme, expr.right);
+  }
+
+  visitVariableExpr(expr: Variable): string {
+    return `var ${expr.name}`;
   }
 
   parenthesize(name: string, ...exprs: Expr[]): string {

--- a/lox/environment.ts
+++ b/lox/environment.ts
@@ -1,0 +1,17 @@
+import { RuntimeError } from "./interpreter";
+import { Token } from "./token";
+
+export class Environment {
+    private values: {[name: string]: object} = {};
+
+    define(name: string, value: object): void {
+        this.values[name] = value;
+    }
+
+    get(name: Token): object {
+        if (name.lexeme in this.values) {
+            return this.values[name.lexeme];
+        }
+        throw new RuntimeError(name, `Undefined variable '${name.lexeme}'`);
+    }
+}

--- a/lox/expr.ts
+++ b/lox/expr.ts
@@ -9,6 +9,7 @@ export interface Visitor<T> {
   visitGroupingExpr(expr: Grouping): T;
   visitLiteralExpr(expr: Literal): T;
   visitUnaryExpr(expr: Unary): T;
+  visitVariableExpr(expr: Variable): T;
 }
 
 
@@ -66,5 +67,19 @@ export class Unary implements Expr {
 
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitUnaryExpr(this);
+  }
+}
+
+
+export class Variable extends Expr {
+  name: Token; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  constructor(name: Token) { // eslint-disable-line @typescript-eslint/no-explicit-any
+    super();
+    this.name = name;
+  }
+
+  accept<T>(visitor: Visitor<T>): T {
+    return visitor.visitVariableExpr(this);
   }
 }

--- a/lox/expr.ts
+++ b/lox/expr.ts
@@ -71,11 +71,10 @@ export class Unary implements Expr {
 }
 
 
-export class Variable extends Expr {
-  name: Token; // eslint-disable-line @typescript-eslint/no-explicit-any
+export class Variable implements Expr {
+  name: Token;
 
-  constructor(name: Token) { // eslint-disable-line @typescript-eslint/no-explicit-any
-    super();
+  constructor(name: Token) {
     this.name = name;
   }
 

--- a/lox/parser.ts
+++ b/lox/parser.ts
@@ -1,6 +1,6 @@
 import { Token } from "./token";
 import { TokenType } from "./token_type";
-import { Binary, Expr, Grouping, Literal, Unary } from "./expr";
+import { Binary, Expr, Grouping, Literal, Unary, Variable } from "./expr";
 import { Expression, Print, Stmt, Var } from "./stmt";
 import { report } from "./errors";
 
@@ -56,7 +56,7 @@ export default class Parser {
   private varDeclaration(): Stmt {
     const name = this.consume(TokenType.IDENTIFIER, "Expect variable name");
 
-    let initializer: Expr | null = null;
+    let initializer: Expr = new Literal(null);
     if (this.match(TokenType.EQUAL)) {
       initializer = this.expression();
     }
@@ -152,6 +152,10 @@ export default class Parser {
 
     if (this.match(TokenType.NUMBER, TokenType.STRING)) {
       return new Literal(this.previous().literal);
+    }
+
+    if (this.match(TokenType.IDENTIFIER)) {
+      return new Variable(this.previous());
     }
 
     if (this.match(TokenType.LEFT_PAREN)) {

--- a/lox/stmt.ts
+++ b/lox/stmt.ts
@@ -38,12 +38,11 @@ export class Print implements Stmt {
 }
 
 
-export class Var extends Stmt {
-  name: Token; // eslint-disable-line @typescript-eslint/no-explicit-any
-  initializer: Expr; // eslint-disable-line @typescript-eslint/no-explicit-any
+export class Var implements Stmt {
+  name: Token;
+  initializer: Expr;
 
-  constructor(name: Token, initializer: Expr) { // eslint-disable-line @typescript-eslint/no-explicit-any
-    super();
+  constructor(name: Token, initializer: Expr) {
     this.name = name;
     this.initializer = initializer;
   }

--- a/lox/stmt.ts
+++ b/lox/stmt.ts
@@ -8,6 +8,7 @@ export interface Stmt {
 export interface Visitor<T> {
   visitExpressionStmt(stmt: Expression): T;
   visitPrintStmt(stmt: Print): T;
+  visitVarStmt(stmt: Var): T;
 }
 
 
@@ -33,5 +34,21 @@ export class Print implements Stmt {
 
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitPrintStmt(this);
+  }
+}
+
+
+export class Var extends Stmt {
+  name: Token; // eslint-disable-line @typescript-eslint/no-explicit-any
+  initializer: Expr; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  constructor(name: Token, initializer: Expr) { // eslint-disable-line @typescript-eslint/no-explicit-any
+    super();
+    this.name = name;
+    this.initializer = initializer;
+  }
+
+  accept<T>(visitor: Visitor<T>): T {
+    return visitor.visitVarStmt(this);
   }
 }

--- a/tools/generate_ast.ts
+++ b/tools/generate_ast.ts
@@ -20,10 +20,12 @@ const RULES = {
       ["Token", "operator"],
       ["Expr", "right"],
     ],
+    Variable: [["Token", "name"]],
   },
   Stmt: {
     Expression: [["Expr", "expression"]],
     Print: [["Expr", "expression"]],
+    Var: [["Token", "name"], ["Expr", "initializer"]],
   },
 };
 


### PR DESCRIPTION
Add support for declaring variables
```
var a = "hello";
var b = "world";

print a + " " + b;
```

There are still issues with variable declaration without initialization, and general `nil` handling. 