### PR TITLE
fix: handle uninitialized variables

### DIFF
--- a/lox/expr.ts
+++ b/lox/expr.ts
@@ -53,6 +53,10 @@ export class Literal implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitLiteralExpr(this);
   }
+
+  toString(): string {
+    return this.value != null ? String(this.value) : "nil";
+  }
 }
 
 

--- a/lox/interpreter.ts
+++ b/lox/interpreter.ts
@@ -46,7 +46,7 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
 
   visitVarStmt(stmt: Var): object {
     let value: object = new Literal(null);
-    if (stmt.initializer != value) {
+    if (stmt.initializer == null) {
       value = this.evaluate(stmt.initializer);
     }
 
@@ -166,10 +166,6 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
   }
 
   private stringify(obj: object): string {
-    const value = obj.valueOf();
-
-    if (value == null) return "nil";
-
-    return `${value}`;
+    return String(obj.valueOf());
   }
 }


### PR DESCRIPTION
Allow variables to be declared without initializing them. This also involves better handling of `nil` literals.