### PR TITLE
fix: actually handle nil

### DIFF
--- a/lox/expr.ts
+++ b/lox/expr.ts
@@ -1,3 +1,6 @@
+/* This is a generated file. Do not manually edit! */
+
+
 import { Token } from "../lox/token";  // eslint-disable-line @typescript-eslint/no-unused-vars
 
 
@@ -52,10 +55,6 @@ export class Literal implements Expr {
 
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitLiteralExpr(this);
-  }
-
-  toString(): string {
-    return this.value != null ? String(this.value) : "nil";
   }
 }
 

--- a/lox/interpreter.ts
+++ b/lox/interpreter.ts
@@ -46,7 +46,8 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
 
   visitVarStmt(stmt: Var): object {
     let value: object = new Literal(null);
-    if (stmt.initializer == null) {
+
+    if (!(stmt.initializer instanceof Literal && stmt.initializer.value == null)) {
       value = this.evaluate(stmt.initializer);
     }
 
@@ -166,6 +167,11 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
   }
 
   private stringify(obj: object): string {
-    return String(obj.valueOf());
+    let value = obj.valueOf();
+    if (value instanceof Literal) {
+      value = value.value;
+    }
+
+    return String(value);
   }
 }

--- a/lox/stmt.ts
+++ b/lox/stmt.ts
@@ -1,3 +1,6 @@
+/* This is a generated file. Do not manually edit! */
+
+
 import { Token } from "../lox/token";  // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Expr } from "../lox/expr";
 

--- a/tools/generate_ast.ts
+++ b/tools/generate_ast.ts
@@ -84,7 +84,9 @@ async function writeAst(dirname: string, basename: string, rules: { [key: string
     .split("/")
     .map(() => "..")
     .join("/");
-  let source = `import { Token } from "${dirDepth}/lox/token";  // eslint-disable-line @typescript-eslint/no-unused-vars\n`;
+  
+  let source = "/* This is a generated file. Do not manually edit! */\n\n\n";
+  source += `import { Token } from "${dirDepth}/lox/token";  // eslint-disable-line @typescript-eslint/no-unused-vars\n`;
   if (basename != "Expr") {
     source += `import { Expr } from "${dirDepth}/lox/expr";\n`;
   }


### PR DESCRIPTION
Realized that the fix I had was a manual edit on an auto-generated file, so it would go away next time I changed the grammar.

Fixed within the interpreter, so it should be stable.