### PR TITLE
feat: add assignment syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A Typescript implementation of the _Lox_ programming language interpreter.
 | statement | exprStmt \| printStmt |
 | exprStmt | expression ";" |
 | printStmt | "print" expression ";" |
-| expression | equality |
+| expression | assignment |
+| assignment | IDENTIFIER "=" assignment \| equality |
 | equality | comparison ( ( "!=" \| "==" ) comparison)* |
 | comparison | term ( ( ">" \| ">=" \| "<" \| "<=" ) term)* |
 | term | factor ( ( "-" \| "+" ) factor)* |

--- a/lox/ast_printer.ts
+++ b/lox/ast_printer.ts
@@ -1,4 +1,4 @@
-import { Binary, Expr, Grouping, Literal, Unary, Variable, Visitor } from "./expr";
+import { Assign, Binary, Expr, Grouping, Literal, Unary, Variable, Visitor } from "./expr";
 
 export class AstPrinter implements Visitor<string> {
   print(expr: Expr): string {
@@ -23,6 +23,10 @@ export class AstPrinter implements Visitor<string> {
 
   visitVariableExpr(expr: Variable): string {
     return `var ${expr.name}`;
+  }
+
+  visitAssignExpr(expr: Assign): string {
+    return `${expr.name} = ${expr.value}`;
   }
 
   parenthesize(name: string, ...exprs: Expr[]): string {

--- a/lox/environment.ts
+++ b/lox/environment.ts
@@ -2,16 +2,23 @@ import { RuntimeError } from "./interpreter";
 import { Token } from "./token";
 
 export class Environment {
-    private values: {[name: string]: object} = {};
+  private values: { [name: string]: object } = {};
 
-    define(name: string, value: object): void {
-        this.values[name] = value;
-    }
+  define(name: string, value: object): void {
+    this.values[name] = value;
+  }
 
-    get(name: Token): object {
-        if (name.lexeme in this.values) {
-            return this.values[name.lexeme];
-        }
-        throw new RuntimeError(name, `Undefined variable '${name.lexeme}'`);
+  get(name: Token): object {
+    if (name.lexeme in this.values) {
+      return this.values[name.lexeme];
     }
+    throw new RuntimeError(name, `Getting undefined variable '${name.lexeme}'`);
+  }
+
+  assign(name: Token, value: object): void {
+    if (name.lexeme in this.values) {
+      this.values[name.lexeme] = value;
+    }
+    throw new RuntimeError(name, `Assigning to undefined variable '${name.lexeme}'`);
+  }
 }

--- a/lox/expr.ts
+++ b/lox/expr.ts
@@ -1,13 +1,12 @@
 /* This is a generated file. Do not manually edit! */
 
-
-import { Token } from "../lox/token";  // eslint-disable-line @typescript-eslint/no-unused-vars
-
+import { Token } from "../lox/token"; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 export interface Expr {
   accept<T>(visitor: Visitor<T>): T;
 }
 export interface Visitor<T> {
+  visitAssignExpr(expr: Assign): T;
   visitBinaryExpr(expr: Binary): T;
   visitGroupingExpr(expr: Grouping): T;
   visitLiteralExpr(expr: Literal): T;
@@ -15,6 +14,22 @@ export interface Visitor<T> {
   visitVariableExpr(expr: Variable): T;
 }
 
+export class Assign implements Expr {
+  name: Token;
+  value: Expr;
+
+  constructor(name: Token, value: Expr) {
+    this.name = name;
+    this.value = value;
+  }
+
+  accept<T>(visitor: Visitor<T>): T {
+    return visitor.visitAssignExpr(this);
+  }
+  toString(): string {
+    return `Assign { name: ${this.name} value: ${this.value} }`;
+  }
+}
 
 export class Binary implements Expr {
   left: Expr;
@@ -30,8 +45,10 @@ export class Binary implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitBinaryExpr(this);
   }
+  toString(): string {
+    return `Binary { left: ${this.left} operator: ${this.operator} right: ${this.right} }`;
+  }
 }
-
 
 export class Grouping implements Expr {
   expression: Expr;
@@ -43,21 +60,26 @@ export class Grouping implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitGroupingExpr(this);
   }
+  toString(): string {
+    return `Grouping { expression: ${this.expression} }`;
+  }
 }
-
 
 export class Literal implements Expr {
   value: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-  constructor(value: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+  constructor(value: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
     this.value = value;
   }
 
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitLiteralExpr(this);
   }
+  toString(): string {
+    return `Literal { value: ${this.value} }`;
+  }
 }
-
 
 export class Unary implements Expr {
   operator: Token;
@@ -71,8 +93,10 @@ export class Unary implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitUnaryExpr(this);
   }
+  toString(): string {
+    return `Unary { operator: ${this.operator} right: ${this.right} }`;
+  }
 }
-
 
 export class Variable implements Expr {
   name: Token;
@@ -83,5 +107,8 @@ export class Variable implements Expr {
 
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitVariableExpr(this);
+  }
+  toString(): string {
+    return `Variable { name: ${this.name} }`;
   }
 }

--- a/lox/interpreter.ts
+++ b/lox/interpreter.ts
@@ -1,4 +1,4 @@
-import { Binary, Expr, Grouping, Literal, Unary, Visitor as ExprVisitor, Variable } from "./expr";
+import { Binary, Expr, Grouping, Literal, Unary, Visitor as ExprVisitor, Variable, Assign } from "./expr";
 import { Expression, Print, Stmt, Visitor as StmtVisitor, Var } from "./stmt";
 import { TokenType } from "./token_type";
 import { Token } from "./token";
@@ -19,7 +19,7 @@ export class RuntimeError extends Error {
 
 export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
   private hasError: boolean = false;
-  private environment = new Environment()
+  private environment = new Environment();
 
   interpret(statements: Stmt[]) {
     try {
@@ -137,6 +137,12 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
     return this.environment.get(expr.name);
   }
 
+  visitAssignExpr(expr: Assign): object {
+    const value = this.evaluate(expr.value);
+    this.environment.assign(expr.name, value);
+    return value;
+  }
+
   evaluate(expr: Expr): object {
     return expr.accept(this);
   }
@@ -153,12 +159,14 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
     return a == b;
   }
 
-  private checkNumberOperand(operator: Token, operand: any) {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  private checkNumberOperand(operator: Token, operand: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
     if (typeof operand == "number") return;
     throw new RuntimeError(operator, `Operand must be a number, not '${typeof operand}' (${operand})`);
   }
 
-  private checkNumberOperands(operator: Token, left: any, right: any) {  // eslint-disable-line @typescript-eslint/no-explicit-any
+  private checkNumberOperands(operator: Token, left: any, right: any) {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
     if (typeof left == "number" && typeof right == "number") return;
     throw new RuntimeError(
       operator,

--- a/lox/stmt.ts
+++ b/lox/stmt.ts
@@ -1,9 +1,7 @@
 /* This is a generated file. Do not manually edit! */
 
-
-import { Token } from "../lox/token";  // eslint-disable-line @typescript-eslint/no-unused-vars
+import { Token } from "../lox/token"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Expr } from "../lox/expr";
-
 
 export interface Stmt {
   accept<T>(visitor: Visitor<T>): T;
@@ -13,7 +11,6 @@ export interface Visitor<T> {
   visitPrintStmt(stmt: Print): T;
   visitVarStmt(stmt: Var): T;
 }
-
 
 export class Expression implements Stmt {
   expression: Expr;
@@ -25,8 +22,10 @@ export class Expression implements Stmt {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitExpressionStmt(this);
   }
+  toString(): string {
+    return `Expression { expression: ${this.expression} }`;
+  }
 }
-
 
 export class Print implements Stmt {
   expression: Expr;
@@ -38,8 +37,10 @@ export class Print implements Stmt {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitPrintStmt(this);
   }
+  toString(): string {
+    return `Print { expression: ${this.expression} }`;
+  }
 }
-
 
 export class Var implements Stmt {
   name: Token;
@@ -52,5 +53,8 @@ export class Var implements Stmt {
 
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitVarStmt(this);
+  }
+  toString(): string {
+    return `Var { name: ${this.name} initializer: ${this.initializer} }`;
   }
 }


### PR DESCRIPTION
Allow for assigning to variables
```
var a = 4;

a = 5;
```
Right now, just variables, but the same code should handle members, etc.