### PR TITLE
feat: add support for lexical scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A Typescript implementation of the _Lox_ programming language interpreter.
 | program | declaration* EOF |
 | declaration | varDecl \| statement |
 | varDecl | "var" IDENTIFIER ( "=" expression )? ";" |
-| statement | exprStmt \| printStmt |
+| statement | exprStmt \| printStmt \| block |
+| block | "{" declaration "}" |
 | exprStmt | expression ";" |
 | printStmt | "print" expression ";" |
 | expression | assignment |

--- a/lox/environment.ts
+++ b/lox/environment.ts
@@ -3,6 +3,11 @@ import { Token } from "./token";
 
 export class Environment {
   private values: { [name: string]: object } = {};
+  private enclosing: Environment | null = null;
+
+  constructor(enclosing: Environment | null = null) {
+    this.enclosing = enclosing;
+  }
 
   define(name: string, value: object): void {
     this.values[name] = value;
@@ -12,6 +17,12 @@ export class Environment {
     if (name.lexeme in this.values) {
       return this.values[name.lexeme];
     }
+
+    // go through enclosing scopes to see if we find anything
+    if (this.enclosing != null) {
+      return this.enclosing.get(name);
+    }
+
     throw new RuntimeError(name, `Getting undefined variable '${name.lexeme}'`);
   }
 
@@ -19,6 +30,13 @@ export class Environment {
     if (name.lexeme in this.values) {
       this.values[name.lexeme] = value;
     }
+
+    // go through enclosing scopes to see if we find anything
+    if (this.enclosing != null) {
+      this.enclosing.assign(name, value);
+      return;
+    }
+
     throw new RuntimeError(name, `Assigning to undefined variable '${name.lexeme}'`);
   }
 }

--- a/lox/parser.ts
+++ b/lox/parser.ts
@@ -1,7 +1,7 @@
 import { Token } from "./token";
 import { TokenType } from "./token_type";
 import { Assign, Binary, Expr, Grouping, Literal, Unary, Variable } from "./expr";
-import { Expression, Print, Stmt, Var } from "./stmt";
+import { Block, Expression, Print, Stmt, Var } from "./stmt";
 import { report } from "./errors";
 
 class ParseError extends Error {}
@@ -68,6 +68,9 @@ export default class Parser {
     if (this.match(TokenType.PRINT)) {
       return this.printStatement();
     }
+    if (this.match(TokenType.LEFT_BRACE)) {
+      return new Block(this.block());
+    }
     return this.expressionStatement();
   }
 
@@ -75,6 +78,20 @@ export default class Parser {
     const expr = this.expression();
     this.consume(TokenType.SEMICOLON, `Expect ';' after value.`);
     return new Print(expr);
+  }
+
+  private block(): Stmt[] {
+    const statements: Stmt[] = [];
+
+    while (!this.check(TokenType.RIGHT_BRACE) && !this.isAtEnd()) {
+      const stmt = this.declaration();
+      if (stmt != null) {
+        statements.push(stmt);
+      }
+    }
+    this.consume(TokenType.RIGHT_BRACE, "Expect '}' after block");
+
+    return statements;
   }
 
   private expressionStatement(): Stmt {

--- a/lox/stmt.ts
+++ b/lox/stmt.ts
@@ -7,9 +7,25 @@ export interface Stmt {
   accept<T>(visitor: Visitor<T>): T;
 }
 export interface Visitor<T> {
+  visitBlockStmt(stmt: Block): T;
   visitExpressionStmt(stmt: Expression): T;
   visitPrintStmt(stmt: Print): T;
   visitVarStmt(stmt: Var): T;
+}
+
+export class Block implements Stmt {
+  statements: Stmt[];
+
+  constructor(statements: Stmt[]) {
+    this.statements = statements;
+  }
+
+  accept<T>(visitor: Visitor<T>): T {
+    return visitor.visitBlockStmt(this);
+  }
+  toString(): string {
+    return `Block { statements: ${this.statements} }`;
+  }
 }
 
 export class Expression implements Stmt {

--- a/lox_files/one.lox
+++ b/lox_files/one.lox
@@ -1,1 +1,23 @@
-var one = 1;
+var a = "global a";
+var b = "global b";
+var c = "global c";
+
+{
+    var a = "outer a";
+    var b = "outer b";
+    {
+        var a = "inner a";
+
+        print a;
+        print b;
+        print c;
+    }
+
+    print a;
+    print b;
+    print c;
+}
+
+print a;
+print b;
+print c;

--- a/tools/generate_ast.ts
+++ b/tools/generate_ast.ts
@@ -27,6 +27,7 @@ const RULES = {
     Variable: [["Token", "name"]],
   },
   Stmt: {
+    Block: [["Stmt[]", "statements"]],
     Expression: [["Expr", "expression"]],
     Print: [["Expr", "expression"]],
     Var: [


### PR DESCRIPTION
Support blocks with their own scope. Right now it is just basic blocks within `{}`.