### PR TITLE
refactor: REPL prints return values

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,37 +7,38 @@ import Scanner from "./lox/scanner";
 import Parser from "./lox/parser";
 import { Interpreter } from "./lox/interpreter";
 
-function run(source: string, interpreter: Interpreter | null = null): boolean {
+function run(source: string, interpreter: Interpreter | null = null): any {
   const scanner = new Scanner(source);
   const tokens = scanner.scanTokens();
 
-  for (const token of tokens) {
-    console.log(token);
-  }
+  // for (const token of tokens) {
+  //   console.log(token);
+  // }
 
-  if (scanner.error) {
-    console.log("Scanner error");
-    return scanner.error;
-  }
+  // if (scanner.error) {
+  //   console.log("Scanner error");
+  //   return scanner.error;
+  // }
 
   //   return scanner.error;
   const parser = new Parser(tokens);
   const statements = parser.parse();
-  if (statements == null || parser.error) {
-    return parser.error;
-  }
+  // if (statements == null || parser.error) {
+  //   return parser.error;
+  // }
 
   interpreter = interpreter || new Interpreter();
-  interpreter.interpret(statements);
-
-  return interpreter.error;
+  return interpreter.interpret(statements);
 }
 
 async function runFile(filename: string) {
   console.log(`Running file '${filename}'`);
 
   const source = await readFile(filename);
-  if (!run(source.toString())) {
+  try {
+    run(source.toString());
+  } catch (ex) {
+    console.log(ex);
     process.exit(65);
   }
 }
@@ -51,14 +52,21 @@ async function runPrompt() {
   });
 
   const interpreter = new Interpreter();
-  for (;;) {
-    const line = await rl.question(">>> ");
-    if (!line) {
-      continue;
+  try {
+    for (;;) {
+      const line = await rl.question(">>> ");
+      if (!line) {
+        continue;
+      }
+      try {
+        console.log(run(line, interpreter));
+      } catch (ex) {
+        console.log(ex);
+      }
     }
-    run(line, interpreter);
+  } finally {
+    rl.close();
   }
-  rl.close();
 }
 
 async function main() {

--- a/lox/expr.ts
+++ b/lox/expr.ts
@@ -26,6 +26,7 @@ export class Assign implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitAssignExpr(this);
   }
+
   toString(): string {
     return `Assign { name: ${this.name} value: ${this.value} }`;
   }
@@ -45,6 +46,7 @@ export class Binary implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitBinaryExpr(this);
   }
+
   toString(): string {
     return `Binary { left: ${this.left} operator: ${this.operator} right: ${this.right} }`;
   }
@@ -60,6 +62,7 @@ export class Grouping implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitGroupingExpr(this);
   }
+
   toString(): string {
     return `Grouping { expression: ${this.expression} }`;
   }
@@ -76,6 +79,7 @@ export class Literal implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitLiteralExpr(this);
   }
+
   toString(): string {
     return `Literal { value: ${this.value} }`;
   }
@@ -93,6 +97,7 @@ export class Unary implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitUnaryExpr(this);
   }
+
   toString(): string {
     return `Unary { operator: ${this.operator} right: ${this.right} }`;
   }
@@ -108,6 +113,7 @@ export class Variable implements Expr {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitVariableExpr(this);
   }
+
   toString(): string {
     return `Variable { name: ${this.name} }`;
   }

--- a/lox/parser.ts
+++ b/lox/parser.ts
@@ -29,6 +29,10 @@ export default class Parser {
       }
     }
 
+    if (this.error) {
+      throw new ParseError();
+    }
+
     return statements;
   }
 

--- a/lox/scanner.ts
+++ b/lox/scanner.ts
@@ -4,6 +4,8 @@ import { error } from "./errors";
 import { isAlpha, isAlphaNumeric, isDigit } from "./utils";
 import keywords from "./keywords";
 
+class ScanError extends Error {}
+
 export default class Scanner {
   private source: string;
   private tokens: Token[];
@@ -28,8 +30,6 @@ export default class Scanner {
   }
 
   scanTokens(): Token[] {
-    console.log("Scanning");
-
     while (!this.isAtEnd()) {
       this.start = this.current;
       this.scanToken();
@@ -37,6 +37,10 @@ export default class Scanner {
 
     // add sentinel for future parsing
     this.tokens.push(new Token(TokenType.EOF, "", null, this.line));
+
+    if (this.error) {
+      throw new ScanError();
+    }
 
     return this.tokens;
   }

--- a/lox/stmt.ts
+++ b/lox/stmt.ts
@@ -23,6 +23,7 @@ export class Block implements Stmt {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitBlockStmt(this);
   }
+
   toString(): string {
     return `Block { statements: ${this.statements} }`;
   }
@@ -38,6 +39,7 @@ export class Expression implements Stmt {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitExpressionStmt(this);
   }
+
   toString(): string {
     return `Expression { expression: ${this.expression} }`;
   }
@@ -53,6 +55,7 @@ export class Print implements Stmt {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitPrintStmt(this);
   }
+
   toString(): string {
     return `Print { expression: ${this.expression} }`;
   }
@@ -70,6 +73,7 @@ export class Var implements Stmt {
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitVarStmt(this);
   }
+
   toString(): string {
     return `Var { name: ${this.name} initializer: ${this.initializer} }`;
   }

--- a/tools/generate_ast.ts
+++ b/tools/generate_ast.ts
@@ -85,6 +85,8 @@ function defineClass(basename: string, name: string, types: string[][]): string 
   classDef += `    return visitor.visit${name}${basename}(this);\n`;
   classDef += `  }\n`;
 
+  classDef += `\n`;
+
   classDef += `  toString(): string {\n`;
   classDef += `    return \`${stringRep}\`;\n`;
   classDef += `  }\n`;


### PR DESCRIPTION
Rather than eating the return values within the REPL, print them so it is easier to know what is going on. This mimics the `nodejs` REPL.

```
npm run interpreter

> typescript-lox@1.0.0 interpreter
> npm run build && node --enable-source-maps build/index.js


> typescript-lox@1.0.0 build
> rimraf ./build && tsc

REPL
>>> var a;
undefined
>>> print a;
nil
undefined
>>> 1+2;
3
>>>
```