### PR TITLE
refactor: clean up interpreter return value in a couple of places

### DIFF
--- a/lox/interpreter.ts
+++ b/lox/interpreter.ts
@@ -128,7 +128,7 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
     }
 
     // unreachable
-    return new Object(null);
+    return new LoxReturnValue(undefined);
   }
 
   visitBinaryExpr(expr: Binary): object {
@@ -172,7 +172,7 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
     }
 
     // unreachable
-    return new Object(null);
+    return new LoxReturnValue(undefined);
   }
 
   visitVariableExpr(expr: Variable): object {


### PR DESCRIPTION
Remove old `Object(null)` value, which does nothing. Neither of these places should ever be executed, but it's still nice to be consistent.