### PR TITLE
feat: add support for parsing and running functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ A Typescript implementation of the _Lox_ programming language interpreter.
 | comparison | term ( ( ">" \| ">=" \| "<" \| "<=" ) term)* |
 | term | factor ( ( "-" \| "+" ) factor)* |
 | factor | unary ( ( "/" \| "\*" ) unary)* |
-| unary | ( "!" \| "-" ) unary | primary |
+| unary | ( "!" \| "-" ) unary | call |
+| call | primary ( "(" arguments? ")" )* |
+| arguments | expression ( "," expression )* |
 | primary | NUMBER \| STRING \| "true" \| "false" \| "nil" \| "(" expression ")" \| IDENTIFIER |
 
 

--- a/index.ts
+++ b/index.ts
@@ -11,9 +11,9 @@ function run(source: string, interpreter: Interpreter | null = null): any {
   const scanner = new Scanner(source);
   const tokens = scanner.scanTokens();
 
-  for (const token of tokens) {
-    console.log(token);
-  }
+  // for (const token of tokens) {
+  //   console.log(token);
+  // }
 
   // if (scanner.error) {
   //   console.log("Scanner error");

--- a/lox/ast_printer.ts
+++ b/lox/ast_printer.ts
@@ -1,4 +1,4 @@
-import { Assign, Binary, Expr, Grouping, Literal, Logical, Unary, Variable, Visitor } from "./expr";
+import { Assign, Binary, Call, Expr, Grouping, Literal, Logical, Unary, Variable, Visitor } from "./expr";
 
 export class AstPrinter implements Visitor<string> {
   print(expr: Expr): string {
@@ -31,6 +31,10 @@ export class AstPrinter implements Visitor<string> {
 
   visitLogicalExpr(expr: Logical): string {
     return `${expr.left} ${expr.operator} ${expr.right}`;
+  }
+
+  visitCallExpr(expr: Call): string {
+    return `${expr.callee}`;
   }
 
   parenthesize(name: string, ...exprs: Expr[]): string {

--- a/lox/builtins.ts
+++ b/lox/builtins.ts
@@ -1,0 +1,15 @@
+import { LoxCallable, LoxReturnValue } from "./internal";
+
+export class ClockBuiltin extends LoxCallable {
+  arity(): number {
+    return 0;
+  }
+
+  call(args: object[]): LoxReturnValue {
+    return new LoxReturnValue(Date.now() / 1000);
+  }
+
+  toString(): string {
+    return "<native fn>";
+  }
+}

--- a/lox/constants.ts
+++ b/lox/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_ARITY = 255;

--- a/lox/expr.ts
+++ b/lox/expr.ts
@@ -8,6 +8,7 @@ export interface Expr {
 export interface Visitor<T> {
   visitAssignExpr(expr: Assign): T;
   visitBinaryExpr(expr: Binary): T;
+  visitCallExpr(expr: Call): T;
   visitGroupingExpr(expr: Grouping): T;
   visitLiteralExpr(expr: Literal): T;
   visitLogicalExpr(expr: Logical): T;
@@ -50,6 +51,26 @@ export class Binary implements Expr {
 
   toString(): string {
     return `Binary { left: ${this.left} operator: ${this.operator} right: ${this.right} }`;
+  }
+}
+
+export class Call implements Expr {
+  callee: Expr;
+  paren: Token;
+  args: Expr[];
+
+  constructor(callee: Expr, paren: Token, args: Expr[]) {
+    this.callee = callee;
+    this.paren = paren;
+    this.args = args;
+  }
+
+  accept<T>(visitor: Visitor<T>): T {
+    return visitor.visitCallExpr(this);
+  }
+
+  toString(): string {
+    return `Call { callee: ${this.callee} paren: ${this.paren} arguments: ${this.args} }`;
   }
 }
 

--- a/lox/internal.ts
+++ b/lox/internal.ts
@@ -1,0 +1,18 @@
+export class LoxCallable {
+  arity(): number {
+    throw new Error("Base class");
+  }
+  call(args: object[]): LoxReturnValue {
+    throw new Error("Base class");
+  }
+}
+
+export class LoxReturnValue {
+  private value: any;
+  constructor(value: any) {
+    this.value = value;
+  }
+  valueOf() {
+    return this.value;
+  }
+}

--- a/lox/interpreter.ts
+++ b/lox/interpreter.ts
@@ -1,4 +1,15 @@
-import { Binary, Expr, Grouping, Literal, Unary, Visitor as ExprVisitor, Variable, Assign, Logical } from "./expr";
+import {
+  Binary,
+  Expr,
+  Grouping,
+  Literal,
+  Unary,
+  Visitor as ExprVisitor,
+  Variable,
+  Assign,
+  Logical,
+  Call,
+} from "./expr";
 import { Block, Break, Expression, If, Print, Stmt, Visitor as StmtVisitor, Var, While } from "./stmt";
 import { TokenType } from "./token_type";
 import { Token } from "./token";
@@ -18,6 +29,15 @@ export class RuntimeError extends Error {
 }
 
 class BreakException extends Error {}
+
+export class LoxCallable {
+  arity(): number {
+    throw new Error("Base class");
+  }
+  call(interpreter: Interpreter, args: object[]): object {
+    throw new Error("Base class");
+  }
+}
 
 export class LoxReturnValue {
   private value: any;
@@ -216,6 +236,26 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
     }
 
     return this.evaluate(expr.right);
+  }
+
+  visitCallExpr(expr: Call): object {
+    const callee = this.evaluate(expr.callee);
+
+    let args: object[] = [];
+    for (const arg of expr.args) {
+      args.push(this.evaluate(arg));
+    }
+
+    if (!(callee instanceof LoxCallable)) {
+      throw new RuntimeError(expr.paren, "Can only call functions and classes");
+    }
+
+    const arity = callee.arity();
+    if (args.length !== arity) {
+      throw new RuntimeError(expr.paren, `Expected ${arity} arguments but got ${args.length}`);
+    }
+
+    return callee.call(this, args);
   }
 
   evaluate(expr: Expr): object {

--- a/lox/interpreter.ts
+++ b/lox/interpreter.ts
@@ -14,6 +14,8 @@ import { Block, Break, Expression, If, Print, Stmt, Visitor as StmtVisitor, Var,
 import { TokenType } from "./token_type";
 import { Token } from "./token";
 import { Environment } from "./environment";
+import { LoxCallable, LoxReturnValue } from "./internal";
+import { ClockBuiltin } from "./builtins";
 
 export class RuntimeError extends Error {
   private _token: Token;
@@ -30,28 +32,14 @@ export class RuntimeError extends Error {
 
 class BreakException extends Error {}
 
-export class LoxCallable {
-  arity(): number {
-    throw new Error("Base class");
-  }
-  call(interpreter: Interpreter, args: object[]): object {
-    throw new Error("Base class");
-  }
-}
-
-export class LoxReturnValue {
-  private value: any;
-  constructor(value: any) {
-    this.value = value;
-  }
-  valueOf() {
-    return this.value;
-  }
-}
-
 export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
   private hasError: boolean = false;
-  private environment = new Environment();
+  private globals = new Environment();
+  private environment = this.globals;
+
+  constructor() {
+    this.globals.define("clock", new ClockBuiltin());
+  }
 
   interpret(statements: Stmt[]): any {
     let res = null;
@@ -255,7 +243,7 @@ export class Interpreter implements StmtVisitor<object>, ExprVisitor<object> {
       throw new RuntimeError(expr.paren, `Expected ${arity} arguments but got ${args.length}`);
     }
 
-    return callee.call(this, args);
+    return callee.call(args);
   }
 
   evaluate(expr: Expr): object {

--- a/tools/generate_ast.ts
+++ b/tools/generate_ast.ts
@@ -18,6 +18,11 @@ const RULES = {
       ["Token", "operator"],
       ["Expr", "right"],
     ],
+    Call: [
+      ["Expr", "callee"],
+      ["Token", "paren"],
+      ["Expr[]", "args"],
+    ],
     Grouping: [["Expr", "expression"]],
     Literal: [["any", "value"]],
     Logical: [


### PR DESCRIPTION
This is the second half of what is needed to make functions work: parsing and interpreting. Functions can still not be declared as the scanner does not handle them yet.

One built in function is present, `clock()`, which gives the number of seconds since the Unix epoch.