### PR TITLE
feat: add function declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ A [Typescript](https://www.typescriptlang.org/) implementation of the _Lox_ prog
 | name | rule |
 |------|------|
 | program | declaration* EOF |
-| declaration | varDecl \| statement |
+| declaration | fnDecl \| varDecl \| statement |
+| fnDecl | "fun" function |
+| function | IDENTIFIER "(" parameters? ")" block |
+| parameters | IDENTIFIER ( "," IDENTIFIER )* |
 | varDecl | "var" IDENTIFIER ( "=" expression )? ";" |
 | statement | exprStmt \| forStmt \| ifStmt \| printStmt \| whileStmt \| block \| breakStmt |
 | breakStmt | "break" ";" |

--- a/index.ts
+++ b/index.ts
@@ -5,9 +5,9 @@ import readline from "node:readline/promises";
 import { readFile } from "node:fs/promises";
 import Scanner from "./lox/scanner";
 import Parser from "./lox/parser";
-import { Interpreter } from "./lox/interpreter";
+import { LoxInterpreter } from "./lox/interpreter";
 
-function run(source: string, interpreter: Interpreter | null = null): any {
+function run(source: string, interpreter: LoxInterpreter | null = null): any {
   const scanner = new Scanner(source);
   const tokens = scanner.scanTokens();
 
@@ -27,7 +27,7 @@ function run(source: string, interpreter: Interpreter | null = null): any {
   //   return parser.error;
   // }
 
-  interpreter = interpreter || new Interpreter();
+  interpreter = interpreter || new LoxInterpreter();
   return interpreter.interpret(statements);
 }
 
@@ -51,7 +51,7 @@ async function runPrompt() {
     output: process.stdout,
   });
 
-  const interpreter = new Interpreter();
+  const interpreter = new LoxInterpreter();
   try {
     for (;;) {
       const line = await rl.question(">>> ");

--- a/lox/builtins.ts
+++ b/lox/builtins.ts
@@ -1,3 +1,4 @@
+import { Interpreter } from "./interfaces";
 import { LoxCallable, LoxReturnValue } from "./internal";
 
 export class ClockBuiltin extends LoxCallable {
@@ -5,7 +6,7 @@ export class ClockBuiltin extends LoxCallable {
     return 0;
   }
 
-  call(args: object[]): LoxReturnValue {
+  call(interpreter: Interpreter, args: object[]): LoxReturnValue {
     return new LoxReturnValue(Date.now() / 1000);
   }
 

--- a/lox/expr.ts
+++ b/lox/expr.ts
@@ -70,7 +70,7 @@ export class Call implements Expr {
   }
 
   toString(): string {
-    return `Call { callee: ${this.callee} paren: ${this.paren} arguments: ${this.args} }`;
+    return `Call { callee: ${this.callee} paren: ${this.paren} args: ${this.args} }`;
   }
 }
 

--- a/lox/interfaces.ts
+++ b/lox/interfaces.ts
@@ -1,0 +1,13 @@
+import { Environment } from "./environment";
+import { Stmt } from "./stmt";
+
+export interface Interpreter {
+  globals: Environment;
+  environment: Environment;
+
+  interpret(statements: Stmt[]): any;
+  get error(): boolean;
+  set error(error: boolean);
+
+  executeBlock(statements: Stmt[], environment: Environment): void;
+}

--- a/lox/internal.ts
+++ b/lox/internal.ts
@@ -1,18 +1,50 @@
-export class LoxCallable {
-  arity(): number {
-    throw new Error("Base class");
-  }
-  call(args: object[]): LoxReturnValue {
-    throw new Error("Base class");
-  }
-}
+import { Interpreter } from "./interfaces";
+import { Func } from "./stmt";
 
+// this should be an interface, but then checking that it is one when running
+// it is not possible, afaict
 export class LoxReturnValue {
   private value: any;
   constructor(value: any) {
     this.value = value;
   }
-  valueOf() {
+  valueOf(): any {
     return this.value;
+  }
+}
+
+export class LoxCallable {
+  arity(): number {
+    throw new Error("Base class");
+  }
+  call(interpreter: Interpreter, args: object[]): LoxReturnValue {
+    throw new Error("Base class");
+  }
+}
+
+export class LoxFunction extends LoxCallable {
+  private declaration: Func;
+
+  constructor(declaration: Func) {
+    super();
+    this.declaration = declaration;
+  }
+
+  arity(): number {
+    return this.declaration.params.length;
+  }
+
+  call(interpreter: Interpreter, args: object[]): LoxReturnValue {
+    const environment = interpreter.globals;
+    for (let i = 0; i < this.declaration.params.length; i++) {
+      environment.define(this.declaration.params[i].lexeme, args[i]);
+    }
+
+    interpreter.executeBlock(this.declaration.body, environment);
+    return new LoxReturnValue(undefined);
+  }
+
+  toString(): string {
+    return `<fn ${this.declaration.name.lexeme} >`;
   }
 }

--- a/lox/keywords.ts
+++ b/lox/keywords.ts
@@ -2,6 +2,7 @@ import { TokenType } from "./token_type";
 
 export default new Map([
   ["and", TokenType.AND],
+  ["break", TokenType.BREAK],
   ["class", TokenType.CLASS],
   ["else", TokenType.ELSE],
   ["false", TokenType.FALSE],
@@ -17,5 +18,4 @@ export default new Map([
   ["true", TokenType.TRUE],
   ["var", TokenType.VAR],
   ["while", TokenType.WHILE],
-  ["break", TokenType.BREAK],
 ]);

--- a/lox/stmt.ts
+++ b/lox/stmt.ts
@@ -10,6 +10,7 @@ export interface Visitor<T> {
   visitBlockStmt(stmt: Block): T;
   visitBreakStmt(stmt: Break): T;
   visitExpressionStmt(stmt: Expression): T;
+  visitFuncStmt(stmt: Func): T;
   visitIfStmt(stmt: If): T;
   visitPrintStmt(stmt: Print): T;
   visitVarStmt(stmt: Var): T;
@@ -57,6 +58,26 @@ export class Expression implements Stmt {
 
   toString(): string {
     return `Expression { expression: ${this.expression} }`;
+  }
+}
+
+export class Func implements Stmt {
+  name: Token;
+  params: Token[];
+  body: Stmt[];
+
+  constructor(name: Token, params: Token[], body: Stmt[]) {
+    this.name = name;
+    this.params = params;
+    this.body = body;
+  }
+
+  accept<T>(visitor: Visitor<T>): T {
+    return visitor.visitFuncStmt(this);
+  }
+
+  toString(): string {
+    return `Func { name: ${this.name} params: ${this.params} body: ${this.body} }`;
   }
 }
 

--- a/lox_files/function.lox
+++ b/lox_files/function.lox
@@ -1,0 +1,7 @@
+fun test(a, b, c) {
+    print a;
+    print b;
+    print c;
+}
+
+test(1, 2, 3);

--- a/tools/generate_ast.ts
+++ b/tools/generate_ast.ts
@@ -40,6 +40,11 @@ const RULES = {
     Block: [["Stmt[]", "statements"]],
     Break: [],
     Expression: [["Expr", "expression"]],
+    Func: [
+      ["Token", "name"],
+      ["Token[]", "params"],
+      ["Stmt[]", "body"],
+    ],
     If: [
       ["Expr", "condition"],
       ["Stmt", "thenBranch"],


### PR DESCRIPTION
Allow functions to be declared and run. Syntax is C-like, but with `fun` keyword:
```
fun test(a, b, c) {
    print a + b + c;
}
```