### PR TITLE
fix: add function block scoping

### DIFF
--- a/lox/internal.ts
+++ b/lox/internal.ts
@@ -1,3 +1,4 @@
+import { Environment } from "./environment";
 import { Interpreter } from "./interfaces";
 import { ReturnException } from "./interpreter";
 import { Func } from "./stmt";
@@ -28,10 +29,12 @@ export class LoxCallable {
 
 export class LoxFunction extends LoxCallable {
   private declaration: Func;
+  private closure: Environment;
 
-  constructor(declaration: Func) {
+  constructor(declaration: Func, closure: Environment) {
     super();
     this.declaration = declaration;
+    this.closure = closure;
   }
 
   arity(): number {
@@ -39,7 +42,7 @@ export class LoxFunction extends LoxCallable {
   }
 
   call(interpreter: Interpreter, args: object[]): LoxReturnValue {
-    const environment = interpreter.globals;
+    const environment = new Environment(this.closure);
     for (let i = 0; i < this.declaration.params.length; i++) {
       environment.define(this.declaration.params[i].lexeme, args[i]);
     }

--- a/lox/interpreter.ts
+++ b/lox/interpreter.ts
@@ -90,7 +90,7 @@ export class LoxInterpreter implements Interpreter, StmtVisitor<object>, ExprVis
   }
 
   visitFuncStmt(stmt: Func): object {
-    const fn = new LoxFunction(stmt);
+    const fn = new LoxFunction(stmt, this.environment);
     this.environment.define(stmt.name.lexeme, fn);
     return new LoxReturnValue(undefined);
   }
@@ -159,7 +159,6 @@ export class LoxInterpreter implements Interpreter, StmtVisitor<object>, ExprVis
 
   visitBreakStmt(stmt: Break): object {
     throw new BreakException();
-    // return new LoxReturnValue(undefined);
   }
 
   visitLiteralExpr(expr: Literal): object {
@@ -252,7 +251,7 @@ export class LoxInterpreter implements Interpreter, StmtVisitor<object>, ExprVis
   }
 
   visitCallExpr(expr: Call): object {
-    const callee = this.evaluate(expr.callee);
+    const callee = this.evaluate(expr.callee).valueOf();
 
     let args: object[] = [];
     for (const arg of expr.args) {

--- a/lox_files/closure.lox
+++ b/lox_files/closure.lox
@@ -1,0 +1,18 @@
+fun makeCounter() {
+    var i = 0;
+
+    fun count() {
+        i = i + 1;
+        print i;
+    }
+
+    return count;
+}
+
+var counter = makeCounter();
+counter();
+counter();
+
+
+// this should fail, since i was created in a different lexical scope
+print i;


### PR DESCRIPTION
The current implementation puts all function variables into the global scope, so they bleed into the rest, and do not support proper lexical scoping to functions. 

True block scoping is still off the table, but this at least allows for function scope and closures.