### PR TITLE
fix: add local scope resolution

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import { readFile } from "node:fs/promises";
 import Scanner from "./lox/scanner";
 import Parser from "./lox/parser";
 import { LoxInterpreter } from "./lox/interpreter";
+import { Resolver } from "./lox/resolver";
 
 function run(source: string, interpreter: LoxInterpreter | null = null): any {
   const scanner = new Scanner(source);
@@ -15,19 +16,14 @@ function run(source: string, interpreter: LoxInterpreter | null = null): any {
   //   console.log(token);
   // }
 
-  // if (scanner.error) {
-  //   console.log("Scanner error");
-  //   return scanner.error;
-  // }
-
-  //   return scanner.error;
   const parser = new Parser(tokens);
   const statements = parser.parse();
-  // if (statements == null || parser.error) {
-  //   return parser.error;
-  // }
 
   interpreter = interpreter || new LoxInterpreter();
+
+  const resolver = new Resolver(interpreter);
+  resolver.resolve(statements);
+
   return interpreter.interpret(statements);
 }
 

--- a/lox/environment.ts
+++ b/lox/environment.ts
@@ -13,6 +13,20 @@ export class Environment {
     this.values[name] = value;
   }
 
+  ancestor(distance: number): Environment {
+    let environment: Environment = this;
+
+    for (let i = 0; i < distance; i++) {
+      if (environment.enclosing == null) {
+        // error
+        break;
+      }
+      environment = environment.enclosing;
+    }
+
+    return environment;
+  }
+
   get(name: Token): object {
     if (name.lexeme in this.values) {
       return this.values[name.lexeme];
@@ -24,6 +38,10 @@ export class Environment {
     }
 
     throw new RuntimeError(name, `Getting undefined variable '${name.lexeme}'`);
+  }
+
+  getAt(distance: number, name: Token): object {
+    return this.ancestor(distance).values[name.lexeme];
   }
 
   assign(name: Token, value: object): void {
@@ -39,5 +57,9 @@ export class Environment {
     }
 
     throw new RuntimeError(name, `Assigning to undefined variable '${name.lexeme}'`);
+  }
+
+  assignAt(distance: number, name: Token, value: object): void {
+    this.ancestor(distance).values[name.lexeme] = value;
   }
 }

--- a/lox/interfaces.ts
+++ b/lox/interfaces.ts
@@ -1,4 +1,5 @@
 import { Environment } from "./environment";
+import { Expr } from "./expr";
 import { Stmt } from "./stmt";
 
 export interface Interpreter {
@@ -10,4 +11,6 @@ export interface Interpreter {
   set error(error: boolean);
 
   executeBlock(statements: Stmt[], environment: Environment): void;
+
+  resolve(expr: Expr, depth: number): void;
 }

--- a/lox/parser.ts
+++ b/lox/parser.ts
@@ -205,8 +205,9 @@ export default class Parser {
   }
 
   private breakStatement(): Stmt {
+    const breakToken = this.previous();
     this.consume(TokenType.SEMICOLON, "Expect ';' after break");
-    return new Break();
+    return new Break(breakToken);
   }
 
   private returnStatement(): Stmt {

--- a/lox/resolver.ts
+++ b/lox/resolver.ts
@@ -1,0 +1,200 @@
+import {
+  Assign,
+  Binary,
+  Call,
+  Expr,
+  Visitor as ExprVisitor,
+  Grouping,
+  Literal,
+  Logical,
+  Unary,
+  Variable,
+} from "./expr";
+import { Interpreter } from "./interfaces";
+import { Block, Break, Expression, Func, If, Print, Return, Stmt, Visitor as StmtVisitor, Var, While } from "./stmt";
+import { Token } from "./token";
+
+class ScopeStack {
+  private scopes: Array<Map<string, boolean>> = new Array<Map<string, boolean>>();
+
+  start(): void {
+    this.scopes.push(new Map<string, boolean>());
+  }
+
+  end(): void {
+    this.scopes.pop();
+  }
+
+  get(index: number): Map<string, boolean> | undefined {
+    return this.scopes[index];
+  }
+
+  get current(): Map<string, boolean> | undefined {
+    return this.scopes[this.scopes.length - 1];
+  }
+
+  get empty(): boolean {
+    return this.scopes.length === 0;
+  }
+
+  get length(): number {
+    return this.scopes.length;
+  }
+}
+
+export class Resolver implements ExprVisitor<void>, StmtVisitor<void> {
+  private interpreter: Interpreter;
+  private scopes = new ScopeStack();
+
+  constructor(interpreter: Interpreter) {
+    this.interpreter = interpreter;
+  }
+
+  resolve(node: Expr | Stmt | Stmt[]): void {
+    if (Array.isArray(node)) {
+      // list of statments
+      for (const stmt of node) {
+        this.resolve(stmt);
+      }
+    } else {
+      node.accept(this);
+    }
+  }
+
+  private resolveLocal(expr: Expr, name: Token): void {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      if (this.scopes.get(i)?.has(name.lexeme)) {
+        this.interpreter.resolve(expr, this.scopes.length - 1 - i);
+        return;
+      }
+    }
+  }
+
+  private resolveFunction(stmt: Func): void {
+    this.beginScope();
+    for (const param of stmt.params) {
+      this.declare(param);
+      this.define(param);
+    }
+    this.resolve(stmt.body);
+    this.endScope();
+  }
+
+  visitBlockStmt(stmt: Block): void {
+    this.beginScope();
+    this.resolve(stmt.statements);
+    this.endScope();
+  }
+
+  visitVarStmt(stmt: Var): void {
+    this.declare(stmt.name);
+    if (stmt.initializer != null) {
+      this.resolve(stmt.initializer);
+    }
+    this.define(stmt.name);
+  }
+
+  visitVariableExpr(expr: Variable): void {
+    if (!this.scopes.empty && this.scopes.current?.get(expr.name.lexeme) === false) {
+      // error
+    }
+
+    this.resolveLocal(expr, expr.name);
+  }
+
+  visitAssignExpr(expr: Assign): void {
+    this.resolve(expr.value);
+    this.resolveLocal(expr, expr.name);
+  }
+
+  visitFuncStmt(stmt: Func): void {
+    this.declare(stmt.name);
+    this.define(stmt.name);
+    this.resolveFunction(stmt);
+  }
+
+  visitExpressionStmt(stmt: Expression): void {
+    this.resolve(stmt.expression);
+  }
+
+  visitIfStmt(stmt: If): void {
+    this.resolve(stmt.condition);
+    this.resolve(stmt.thenBranch);
+    if (stmt.elseBranch != null) {
+      this.resolve(stmt.elseBranch);
+    }
+  }
+
+  visitPrintStmt(stmt: Print): void {
+    this.resolve(stmt.expression);
+  }
+
+  visitReturnStmt(stmt: Return): void {
+    if (stmt.value != null) {
+      this.resolve(stmt.value);
+    }
+  }
+
+  visitWhileStmt(stmt: While): void {
+    this.resolve(stmt.condition);
+    this.resolve(stmt.body);
+  }
+
+  visitBinaryExpr(expr: Binary): void {
+    this.resolve(expr.left);
+    this.resolve(expr.right);
+  }
+
+  visitBreakStmt(stmt: Break): void {
+    // no expression to resolve
+  }
+
+  visitCallExpr(expr: Call): void {
+    this.resolve(expr.callee);
+
+    for (const arg of expr.args) {
+      this.resolve(arg);
+    }
+  }
+
+  visitGroupingExpr(expr: Grouping): void {
+    this.resolve(expr.expression);
+  }
+
+  visitLiteralExpr(expr: Literal): void {
+    // no expression to resolve
+  }
+
+  visitLogicalExpr(expr: Logical): void {
+    this.resolve(expr.left);
+    this.resolve(expr.right);
+  }
+
+  visitUnaryExpr(expr: Unary): void {
+    this.resolve(expr.right);
+  }
+
+  private declare(name: Token): void {
+    const scope = this.scopes.current;
+    if (scope == undefined) return;
+
+    // set the variable as false, to indicate that it is not defined
+    scope.set(name.lexeme, false);
+  }
+
+  private define(name: Token): void {
+    const scope = this.scopes.current;
+    if (scope == undefined) return;
+
+    // set the variable to true, to indicate that it is defined and available
+    scope.set(name.lexeme, true);
+  }
+
+  private beginScope(): void {
+    this.scopes.start();
+  }
+
+  private endScope(): void {
+    this.scopes.end();
+  }
+}

--- a/lox/stmt.ts
+++ b/lox/stmt.ts
@@ -35,14 +35,18 @@ export class Block implements Stmt {
 }
 
 export class Break implements Stmt {
-  constructor() {}
+  token: Token;
+
+  constructor(token: Token) {
+    this.token = token;
+  }
 
   accept<T>(visitor: Visitor<T>): T {
     return visitor.visitBreakStmt(this);
   }
 
   toString(): string {
-    return `Break { }`;
+    return `Break { token: ${this.token} }`;
   }
 }
 

--- a/lox_files/scope.lox
+++ b/lox_files/scope.lox
@@ -1,0 +1,12 @@
+var a = "global";
+
+{
+    fun showA() {
+        print a;
+    }
+
+    showA();
+
+    var a = "block";
+    showA();
+}

--- a/tools/generate_ast.ts
+++ b/tools/generate_ast.ts
@@ -38,7 +38,7 @@ const RULES = {
   },
   Stmt: {
     Block: [["Stmt[]", "statements"]],
-    Break: [],
+    Break: [["Token", "token"]],
     Expression: [["Expr", "expression"]],
     Func: [
       ["Token", "name"],


### PR DESCRIPTION
Currently lexical scope mostly works as expected. However, one aspect of scoping is that once resolved, a name should remain resolved to the same element. That is the case for the most part, but if a function closes around a variable, and then it is shadowed in the same scope, calls will refer to different elements.

For instance:
```
var a = "global";

{
    fun test() {
        print a;
    }

    test();

    var a = "local";

   test();
}
```

The first call to `test()` will resolve to the global `a`, while the second will resolve to the local variable. This is a problem. Once resolved it should not change.

This PR fixes this by doing static resolution of variables, during a second pass through the AST.

